### PR TITLE
fix: 모달창 프로그레스바 버그 수정

### DIFF
--- a/client/src/components/SNS/Story/Modal.jsx
+++ b/client/src/components/SNS/Story/Modal.jsx
@@ -4,34 +4,7 @@ import { FaRegPaperPlane } from 'react-icons/fa';
 import ProgressBar from '../../ProgressBar/ProgressBar';
 import * as S from './ModalStyle';
 
-function Modal({ isOpen, src, username, handleOpenModal }) {
-  const [persent, setPersent] = useState('0%');
-
-  useEffect(() => {
-    setTimeout(() => {
-      setPersent('0%');
-    }, 1000);
-    setTimeout(() => {
-      setPersent('20%');
-    }, 2000);
-    setTimeout(() => {
-      setPersent('40%');
-    }, 3000);
-    setTimeout(() => {
-      setPersent('60%');
-    }, 4000);
-    setTimeout(() => {
-      setPersent('80%');
-    }, 5000);
-    setTimeout(() => {
-      setPersent('100%');
-    }, 6000);
-    // setTimeout(() => {
-    //   const tempCloser = window.location.reload();
-    //   return tempCloser;
-    // }, 6500);
-  }, []);
-
+function Modal({ persent, isOpen, setIsOpen, src, username, handleOpenModal }) {
   return (
     <S.ModalLayout isOpen={isOpen}>
       <S.ModalContainer src={src}>

--- a/client/src/components/SNS/Story/Story.jsx
+++ b/client/src/components/SNS/Story/Story.jsx
@@ -4,9 +4,37 @@ import Modal from './Modal';
 
 function Story({ id, src, index, username }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [persent, setPersent] = useState('0%');
 
-  const handleOpenModal = () => setIsOpen(!isOpen);
+  const timer = () => {
+    setTimeout(() => {
+      setPersent('0%');
+    }, 1000);
+    setTimeout(() => {
+      setPersent('20%');
+    }, 2000);
+    setTimeout(() => {
+      setPersent('40%');
+    }, 3000);
+    setTimeout(() => {
+      setPersent('60%');
+    }, 4000);
+    setTimeout(() => {
+      setPersent('80%');
+    }, 5000);
+    setTimeout(() => {
+      setPersent('100%');
+    }, 6000);
+    setTimeout(() => {
+      setPersent('0%');
+      setIsOpen(false);
+    }, 6500);
+  };
 
+  const handleOpenModal = () => {
+    setIsOpen(!isOpen);
+    timer();
+  };
   return (
     <>
       <S.StoryCircle
@@ -22,6 +50,7 @@ function Story({ id, src, index, username }) {
         setIsOpen={setIsOpen}
         handleOpenModal={handleOpenModal}
         username={username}
+        persent={persent}
       />
     </>
   );


### PR DESCRIPTION
프로그레스 바 진행 퍼센테이지의 state를 변경하는 함수를 기존에 Modal 컴포넌트에서 useEffect hook 내부에서 사용하였을 때, Story 컴포넌트 클릭시 팝업되는 모달창 프로그레스 바 100% 진행 시 모달창 닫아진 후 다른 모달창 클릭 시 프로그레스 바 진행이 안 되던 버그가 있었습니다.

그래서 useEffect 훅을 걷어내며 Modal 컴포넌트는 props만 받아 프로그레스 바에 전달만 시켜주도록 변경하고 ProgressBar 진행 퍼센테이지의 state는 한단계 부모인 Story 컴포넌트에서 timer 함수를 정의해서 setState 했습니다. 그리고 모달창을 여닫는 handleOpenModal 함수 안에서 setIsOpen(!isOpen) 한 후에 timer 함수를 실행시켜서 최종적으로 원하는 모습으로 구현이 완료되었습니다.