### PR TITLE
fix: 모바일버튼에서 단건 게시글 요청 data로 editsnsform에 props로 전달

### DIFF
--- a/client/src/components/SNS/PopUp/MobileButtonDetail.jsx
+++ b/client/src/components/SNS/PopUp/MobileButtonDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { DownOutlined } from '@ant-design/icons';
 import { Menu, Space } from 'antd';
@@ -6,8 +6,20 @@ import { MobileDetailLayOut } from './PopUpStyle';
 import MoreIcon from '../../../assets/more.png';
 import SnsEditForm from '../../Form/sns/SnsEditForm';
 
-function MobileButtonDetail({ item }) {
+function MobileButtonDetail({ item, index }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const editPost = async () => {
+      const getPost = await axios.get(
+        `https://server.staybuddy.net/api/posts2/${index}`,
+      );
+      const res = getPost.data.image;
+      setData(res);
+    };
+    editPost();
+  });
 
   const handleOpenModal = () => {
     return setIsOpen(!isOpen);
@@ -93,6 +105,8 @@ function MobileButtonDetail({ item }) {
         </button>
       </MobileDetailLayOut>
       <SnsEditForm
+        data={data}
+        index={index}
         isOpen={isOpen}
         setIsOpen={setIsOpen}
         handleOpenModal={handleOpenModal}

--- a/client/src/components/SNS/SingleFeed/SingleFeed.jsx
+++ b/client/src/components/SNS/SingleFeed/SingleFeed.jsx
@@ -73,7 +73,7 @@ function SingleFeed() {
           {feed?.map((item) => {
             return (
               <SingleFeedInfinite key={item.id}>
-                <SingleFeedTopBar item={item} />
+                <SingleFeedTopBar index={item.id} item={item} />
                 <SingleFeedImage item={item} />
                 <SigleFeedContent item={item} />
               </SingleFeedInfinite>

--- a/client/src/components/SNS/SingleFeed/SingleFeedTopBar.jsx
+++ b/client/src/components/SNS/SingleFeed/SingleFeedTopBar.jsx
@@ -7,7 +7,7 @@ import {
 } from './SingleFeedTopBarStyle';
 import MobileButtonDetail from '../PopUp/MobileButtonDetail';
 
-function SingleFeedTopBar({ item }) {
+function SingleFeedTopBar({ item, index }) {
   const navigate = useNavigate();
 
   const UserFeed = () => {
@@ -23,7 +23,7 @@ function SingleFeedTopBar({ item }) {
         />
         {item.username}
       </SingleFeedUser>
-      <MobileButtonDetail item={item} />
+      <MobileButtonDetail index={index} item={item} />
     </SingleFeedTopBarLayout>
   );
 }


### PR DESCRIPTION
# PR 요청

## PR 요청 연관이슈

현재 해결된 부분 
현재 모바일 버튼 팝업에 수정 버튼 클릭시 해당 게시물 단건 조회 가능해 졌고 
snsEditForm에 요청한 단건 데이터 값 전달 했습니다 

현호님께 요청 사항 
snsEditForm에서 전달된 값이 인풋에 보여지게 하고 
유저가 수정 한것이 업데이트가 되야 합니다 

## PR 요청 내용

[ 작업한 내용의 설명을 적어주세요. 상세하면 더욱더 좋습니다. ]
ex) Oauth 2.0을 이용해서 카카오 로그인 & 카카오 로그아웃 기능을 추가했습니다.

## 에러 또는 도움이 필요한 부분 요청사항

[ 해결하지 못한 문제가 있다면 공유해주세요. ]

## 참고 링크 & 스크린샷

[ Issues 해결에 관한 도움을 줄 수 있는 링크나 스크린샷을 올려주세요. Issues가 없으면 지워주세요. ]

## 체크리스트

- [ ] git commit message 준수
      Ex) docs: 파일명 파일 상태
- [ ] Pull Request 대상 파일 확인
- [ ] Branch 확인
- [ ] Labels 확인
